### PR TITLE
Add Google Universal Analytics support

### DIFF
--- a/lib/assets/javascripts/google-analytics-turbolinks.js.coffee
+++ b/lib/assets/javascripts/google-analytics-turbolinks.js.coffee
@@ -2,7 +2,10 @@ if window.history?.pushState and window.history.replaceState
   document.addEventListener 'page:change', (event) =>
 
     # Google Analytics
-    if window._gaq != undefined
+    if window.ga != undefined
+      ga('set', 'location', location.href.split('#')[0])
+      ga('send', 'pageview')
+    else if window._gaq != undefined
       _gaq.push(['_trackPageview'])
     else if window.pageTracker != undefined
       pageTracker._trackPageview();


### PR DESCRIPTION
This is the update which adds Universal Analytics support.
In order to send the correct 'location', I used [ga('set', 'location') method](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#location). This may be wrong.
