### PR TITLE
skip `ga('send', 'pageview'` when normal access

### DIFF
--- a/lib/assets/javascripts/google-analytics-turbolinks.js.coffee
+++ b/lib/assets/javascripts/google-analytics-turbolinks.js.coffee
@@ -3,8 +3,13 @@ if window.history?.pushState and window.history.replaceState
 
     # Google Analytics
     if window.ga != undefined
-      ga('set', 'location', location.href.split('#')[0])
-      ga('send', 'pageview')
+      ga (tracker) ->
+        turbolinked = tracker.get('turbolink?') || false
+        unless turbolinked
+          ga 'set', 'turbolink?', true
+        else
+          ga 'set', 'location', location.href.split(/#/)[0]
+          ga 'send', 'pageview'
     else if window._gaq != undefined
       _gaq.push(['_trackPageview'])
     else if window.pageTracker != undefined


### PR DESCRIPTION
if you copied snippet from document of google analytics (and i think it is expected), 
`ga('send', 'pageview')` called twice when acceess normaly,
because of both html and page:change event will call it.
so I add variable to check `page:change` is called from turbolinks or not.

if you expect html does not contain `ga('send', 'pageview')`,
you should care browsers that can't use history.pushState like this.

``` coffee
if window.history?.pushState and window.history.replaceState
  document.addEventListener 'page:change', (event) =>
    if window.ga != undefined
      ...
else
 if window.ga != undefined
   ga('send', 'pageview')
 else if window._gaq != undefined
   ...

```
